### PR TITLE
Make Lib Jenkins Maven really buildable after update to Guice 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ### 3.12
 
-Release date: TBD, 2017
+Release date: Jan 16, 2017
 
 * [JENKINS-40621](https://issues.jenkins-ci.org/browse/JENKINS-40621) - 
 Prevent leaked file descriptorswhen invoking `MavenEmbedderUtils#getMavenVersion()`

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@ under the License.
     <aetherVersion>0.9.0.M2</aetherVersion>
     <mavenVersion>3.1.0</mavenVersion>
     <wagonVersion>2.4</wagonVersion>
-    <sisuInjectVersion>0.0.0.M2a</sisuInjectVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4jVersion>1.7.4</slf4jVersion>
   </properties>
@@ -95,7 +94,7 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <version>${sisuInjectVersion}</version>
+      <version>0.3.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.sonatype.sisu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ under the License.
   </scm>
   
   <properties>
-    <aetherVersion>0.9.0.M2</aetherVersion>
+    <aetherVersion>1.1.0</aetherVersion>
     <mavenVersion>3.1.0</mavenVersion>
     <wagonVersion>2.4</wagonVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -112,7 +112,7 @@ under the License.
 
     <dependency>
       <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-wagon</artifactId>
+      <artifactId>aether-transport-wagon</artifactId>
       <version>${aetherVersion}</version>
       <exclusions>
         <exclusion>

--- a/src/main/java/hudson/maven/MavenEmbedderUtils.java
+++ b/src/main/java/hudson/maven/MavenEmbedderUtils.java
@@ -43,7 +43,6 @@ import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.util.IOUtil;
-import org.eclipse.sisu.BeanScanning;
 
 
 /**


### PR DESCRIPTION
Previously it was building locally with clean verify, but when I tried a release profile the code has blown up due to the missing classes. I had to update sisu.plexus in order to fix it. Also updated Aether since there were missing dependencies around.

`sisu.plexus` is not binary compatible from what I see. Do we care about it much?

CC @jenkinsci/code-reviewers and @reviewbybees 