### PR TITLE
Revert "Use Guice 4.0 instead of the beta release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release date: TBD, 2017
 * [JENKINS-40621](https://issues.jenkins-ci.org/browse/JENKINS-40621) - 
 Prevent leaked file descriptorswhen invoking `MavenEmbedderUtils#getMavenVersion()`
 ([PR #5](https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/5))
-* Update from sisu-guide `3.1.3` to guice `4.0`
+* Update to Guice `4.0-beta`
 * Update plexus-classworlds from `2.4.2` to `2.5.1`
 
 ### 3.11

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>4.0-beta</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Reverts jenkinsci/lib-jenkins-maven-embedder#7