### PR TITLE
[JENKINS-42549, JENKINS-40621] - Handle fallout after #5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,18 @@ under the License.
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>test-annotations</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   
   <build>

--- a/src/main/java/hudson/maven/MavenEmbedderCallable.java
+++ b/src/main/java/hudson/maven/MavenEmbedderCallable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Oleg Nenashev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hudson.maven;
+
+/**
+ * Callable interface for the Maven Embedder logic.
+ * 
+ * Used primarily for testing purposes.
+ * @author Oleg Nenashev
+ */
+/*package*/ interface MavenEmbedderCallable {
+    
+    public void call() throws MavenEmbedderException;
+}

--- a/src/main/java/hudson/maven/MavenEmbedderUtils.java
+++ b/src/main/java/hudson/maven/MavenEmbedderUtils.java
@@ -32,6 +32,8 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.tools.ant.AntClassLoader;
@@ -179,14 +181,17 @@ public class MavenEmbedderUtils
         }
     }
         
-    
-    
     /**
-     * @param mavenHome
+     * @param mavenHome Maven Home directory
      * @return the maven version 
-     * @throws MavenEmbedderException
+     * @throws MavenEmbedderException Operation failure
      */
-    public static MavenInformation getMavenVersion(File mavenHome) throws MavenEmbedderException {
+    public static MavenInformation getMavenVersion(@Nonnull File mavenHome) throws MavenEmbedderException {
+        return getMavenVersion(mavenHome, null);
+    }
+    
+    /*package*/ static MavenInformation getMavenVersion(@Nonnull File mavenHome, 
+            @CheckForNull MavenEmbedderCallable preopertiesPreloadHook) throws MavenEmbedderException {
         
         ClassRealm realm = buildClassRealm( mavenHome, null, null );
         if (debug) {
@@ -213,6 +218,9 @@ public class MavenEmbedderUtils
                     final JarEntry entry = (entryName != null && jarFile != null) ? jarFile.getJarEntry(entryName) : null;
                     if (entry != null) {
                         inputStream = jarFile.getInputStream(entry);
+                        if (preopertiesPreloadHook != null) {
+                            preopertiesPreloadHook.call();
+                        }
                         Properties properties = new Properties();
                         properties.load( inputStream );
                         information = new MavenInformation( properties.getProperty( "version" ) , resource.toExternalForm() );


### PR DESCRIPTION
In https://github.com/jenkinsci/lib-jenkins-maven-embedder/pull/5 there was an attempt to fix [JENKINS-40621](https://issues.jenkins-ci.org/browse/JENKINS-40621), but effectively wrong code has been changed. It caused another regression in parallel request handling due to the File session caching in `JarURLConnection` - [JENKINS-42549](https://issues.jenkins-ci.org/browse/JENKINS-42549).

This pull request fixes the regression and the original issue. At least I see no leaked File descriptors after the fix, and the code is working.

@reviewbybees @abayer @aheritier 