### PR TITLE
Readme: Document baselines to prevent confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ Jenkins Maven Embedder Library
 
 Library for Jenkins plugins and other components, which allows embedding Maven into their logic.
 
+## Baselines
+
+Currently there are 2 library baselines:
+
+* [maven-3.1.0](https://github.com/jenkinsci/lib-jenkins-maven-embedder/tree/maven-3.1.0) - Maven 3.1.0 compatibility baseline
+  * This baseline is used in the [Maven Integration Plugin](https://plugins.jenkins.io/maven-plugin).
+  * Version format: 3.x
+* [maven-3.5.0](https://github.com/jenkinsci/lib-jenkins-maven-embedder/tree/maven-3.5.0) - Experimental version for Maven 3.5.0 and newer
+  * Version format: 4.x-maven-3.5
+
 ### Changelog
 
 See the [CHANGELOG](CHANGELOG.md) page.


### PR DESCRIPTION
I am splitting the project to two baselines for now, because we need to maintain the Maven 3.1.0 compatibility for a while in Maven plugin. After the releases of JEP-200 we can reconsider that and drop support of Maven versions older than 3.5.0

@reviewbybees @aheritier @jglick @emsouza


  